### PR TITLE
Updated ioredis to version 1.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "express": "4.13.3",
     "express-session": "^1.11.3",
     "hbs": "3.1.1",
-    "ioredis": "1.8.0",
+    "ioredis": "1.9.1",
     "passport": "0.3.0",
     "passport-runkeeper": "^0.1.2",
     "request": "2.62.0"


### PR DESCRIPTION
:rocket:

ioredis just published version 1.9.1, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

The new version differs by 30 commits (ahead by 30, behind by 0).
- [41f4d8e](https://github.com/luin/ioredis/commit/41f4d8efca89cbef422ad50dc2b66654a2e6d848): 1.9.1
- [9fb3ad1](https://github.com/luin/ioredis/commit/9fb3ad1a91b9b23bd2d834c8cee5bc42b125abab): Update Contributors
- [5d97977](https://github.com/luin/ioredis/commit/5d97977bdb5142536a31e7ab74d621828d02ec5d): Fix debug output
- [03acced](https://github.com/luin/ioredis/commit/03acced0ee4e50c69b5fae0d1952e3b6dbd0290f): Merge pull request #165 from luin/auth-error
- [a8399fc](https://github.com/luin/ioredis/commit/a8399fc513ace75398b57799f9a89da95260ec45): Update tests and doc
- [1d36168](https://github.com/luin/ioredis/commit/1d36168e30765f417055369480d4b7df01c508c3): Fix tests for pubsub
- [61be901](https://github.com/luin/ioredis/commit/61be90191449abb7eea6641fc257551fe62d5331): Correct the debug info when connecting to the unix domain socks
- [5e3ba24](https://github.com/luin/ioredis/commit/5e3ba241f5300aa4bff1b1235b0d3fb7f15da250): Merge pull request #157 from ColmHally/master
- [7bcd67e](https://github.com/luin/ioredis/commit/7bcd67e60f06e63a61f8529a7402b3b7c463953e): Emit auth error for wrong password
- [d79913c](https://github.com/luin/ioredis/commit/d79913c34e98f09ad8b8d70fc2981b9ad0719aa7): Merge pull request #162 from mtlima/down-slave
- [076cb21](https://github.com/luin/ioredis/commit/076cb21673bf0b14529a8516c7550a496044d970): Discard slave if flagged with s_down or o_down
- [589b484](https://github.com/luin/ioredis/commit/589b48489bec11273362440b21d4e8ca1ef4c731): Merge pull request #160 from pensierinmusica/patch-1
- [c8bcac9](https://github.com/luin/ioredis/commit/c8bcac9e2191e61777db0032f32e344b1bd79112): Added example in docs to create keys with expires
- [3c1c381](https://github.com/luin/ioredis/commit/3c1c381a07f2674509af39768ba17a9d569c6844): Print address of connected Redis server in debug statements
- [cef4cce](https://github.com/luin/ioredis/commit/cef4cce3e16755629c70f78e6ddd0bc8ce25ca44): Merge pull request #155 from ColmHally/master

There are 30 commits in total. See the [full diff](https://github.com/luin/ioredis/compare/a0d7dbfa34fcbc81def010e1a1969683cd20d1f3...41f4d8efca89cbef422ad50dc2b66654a2e6d848).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
