### PR TITLE
Updated connect-redis to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/benfoxall/rk-data",
   "dependencies": {
-    "connect-redis": "2.5.1",
+    "connect-redis": "3.0.0",
     "dotenv": "^1.2.0",
     "express": "4.13.3",
     "express-session": "^1.11.3",


### PR DESCRIPTION
:rocket:

connect-redis just published version 3.0.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

The new version differs by 6 commits (ahead by 6, behind by 0).
- [67a7acb](https://github.com/tj/connect-redis/commit/67a7acb883bc1e8138058972a06d90268f8b581a): Release 3.0.0
- [0fc01cc](https://github.com/tj/connect-redis/commit/0fc01ccc8f5e45da7f5119333f538cf06f037026): Update readme
- [ff2e103](https://github.com/tj/connect-redis/commit/ff2e103c6907db9f60a543f1e23e5e307afb7f1c): Update deps, and lint
- [c0a1978](https://github.com/tj/connect-redis/commit/c0a19787322c9e6574d184ff112b2f8aa9c94fd5): Update other deps
- [cbc9c0d](https://github.com/tj/connect-redis/commit/cbc9c0d8c1d89cceb168ce2b4f009f3b8c7c3b21): Merge branch 'fintura-master'
- [334e9ef](https://github.com/tj/connect-redis/commit/334e9efff620fff5a4154c89118baf195e42a2e0): Update node redis to 2.0

See the [full diff](https://github.com/tj/connect-redis/compare/dcbc43d0ce8bb7808fcffc3f70f9de2d85bfa0d2...67a7acb883bc1e8138058972a06d90268f8b581a).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
